### PR TITLE
Add carthage support

### DIFF
--- a/BOSImageResizeOperation/BOSImageResizeOperation.m
+++ b/BOSImageResizeOperation/BOSImageResizeOperation.m
@@ -166,7 +166,7 @@ static inline CGFloat degrees2radians(CGFloat degrees) {
             break;
         default:
             // TODO: set the error and/or support other orientations
-            NSLog(@"Orientation not supported: %d", self.imageToResize.imageOrientation);
+            NSLog(@"Orientation not supported: %ld", (long)self.imageToResize.imageOrientation);
             CGContextRelease(bitmap);
             return;
     }

--- a/BOSImageResizeOperation/Supporting files/Info.plist
+++ b/BOSImageResizeOperation/Supporting files/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+
 BOSImageResizeOperation
 =======================
 

--- a/Tests/BOSImageResizeOperation.xcodeproj/project.pbxproj
+++ b/Tests/BOSImageResizeOperation.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		37F03FE21E374AE300548C03 /* BOSImageResizeOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F68A720A16EA8A1A00DF589B /* BOSImageResizeOperation.m */; };
+		37F03FEE1E374F3900548C03 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 37F03FEB1E374F3900548C03 /* Info.plist */; };
+		37F03FEF1E3750C900548C03 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F68A71D516EA898900DF589B /* Foundation.framework */; };
+		37F03FF01E3750CE00548C03 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F68A71D316EA898900DF589B /* UIKit.framework */; };
+		37F03FF11E3750D300548C03 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F68A71D716EA898900DF589B /* CoreGraphics.framework */; };
+		37F03FF21E3753D300548C03 /* BOSImageResizeOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = F68A720916EA8A1A00DF589B /* BOSImageResizeOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F68A721A16EA8B9000DF589B /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F68A71F116EA898900DF589B /* SenTestingKit.framework */; };
 		F68A721B16EA8B9000DF589B /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F68A71D316EA898900DF589B /* UIKit.framework */; };
 		F68A721C16EA8B9000DF589B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F68A71D516EA898900DF589B /* Foundation.framework */; };
@@ -34,6 +40,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		37F03FD51E373C9C00548C03 /* BOSImageResizeOperation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BOSImageResizeOperation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		37F03FEB1E374F3900548C03 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F68A71D316EA898900DF589B /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		F68A71D516EA898900DF589B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		F68A71D716EA898900DF589B /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -66,6 +74,16 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		37F03FD11E373C9C00548C03 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				37F03FF11E3750D300548C03 /* CoreGraphics.framework in Frameworks */,
+				37F03FF01E3750CE00548C03 /* UIKit.framework in Frameworks */,
+				37F03FEF1E3750C900548C03 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F68A721516EA8B9000DF589B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -80,6 +98,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		37F03FE91E374F3900548C03 /* Supporting files */ = {
+			isa = PBXGroup;
+			children = (
+				37F03FEB1E374F3900548C03 /* Info.plist */,
+			);
+			path = "Supporting files";
+			sourceTree = "<group>";
+		};
 		F68A71C716EA898900DF589B = {
 			isa = PBXGroup;
 			children = (
@@ -94,6 +120,7 @@
 			isa = PBXGroup;
 			children = (
 				F68A721916EA8B9000DF589B /* BOSImageResizeOperationTests.octest */,
+				37F03FD51E373C9C00548C03 /* BOSImageResizeOperation.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -114,6 +141,7 @@
 			children = (
 				F68A720916EA8A1A00DF589B /* BOSImageResizeOperation.h */,
 				F68A720A16EA8A1A00DF589B /* BOSImageResizeOperation.m */,
+				37F03FE91E374F3900548C03 /* Supporting files */,
 			);
 			name = BOSImageResizeOperation;
 			path = ../BOSImageResizeOperation;
@@ -166,7 +194,36 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		37F03FD21E373C9C00548C03 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				37F03FF21E3753D300548C03 /* BOSImageResizeOperation.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		37F03FD41E373C9C00548C03 /* BOSImageResizeOperation */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 37F03FDA1E373C9D00548C03 /* Build configuration list for PBXNativeTarget "BOSImageResizeOperation" */;
+			buildPhases = (
+				37F03FD01E373C9C00548C03 /* Sources */,
+				37F03FD11E373C9C00548C03 /* Frameworks */,
+				37F03FD21E373C9C00548C03 /* Headers */,
+				37F03FD31E373C9C00548C03 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BOSImageResizeOperation;
+			productName = BOSImageResizeOperation;
+			productReference = 37F03FD51E373C9C00548C03 /* BOSImageResizeOperation.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		F68A721816EA8B9000DF589B /* BOSImageResizeOperationTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F68A722716EA8B9000DF589B /* Build configuration list for PBXNativeTarget "BOSImageResizeOperationTests" */;
@@ -194,6 +251,12 @@
 				CLASSPREFIX = BOS;
 				LastUpgradeCheck = 0460;
 				ORGANIZATIONNAME = "Bucket o' Software";
+				TargetAttributes = {
+					37F03FD41E373C9C00548C03 = {
+						CreatedOnToolsVersion = 8.2.1;
+						ProvisioningStyle = Automatic;
+					};
+				};
 			};
 			buildConfigurationList = F68A71CB16EA898900DF589B /* Build configuration list for PBXProject "BOSImageResizeOperation" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -207,12 +270,21 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				37F03FD41E373C9C00548C03 /* BOSImageResizeOperation */,
 				F68A721816EA8B9000DF589B /* BOSImageResizeOperationTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		37F03FD31E373C9C00548C03 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				37F03FEE1E374F3900548C03 /* Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F68A721616EA8B9000DF589B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -257,6 +329,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		37F03FD01E373C9C00548C03 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				37F03FE21E374AE300548C03 /* BOSImageResizeOperation.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F68A721416EA8B9000DF589B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -280,6 +360,91 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		37F03FDB1E373C9D00548C03 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/../BOSImageResizeOperation/Supporting files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bucketosoftware.BOSImageResizeOperation;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		37F03FDC1E373C9D00548C03 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/../BOSImageResizeOperation/Supporting files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bucketosoftware.BOSImageResizeOperation;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		F68A720016EA898900DF589B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -371,6 +536,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		37F03FDA1E373C9D00548C03 /* Build configuration list for PBXNativeTarget "BOSImageResizeOperation" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				37F03FDB1E373C9D00548C03 /* Debug */,
+				37F03FDC1E373C9D00548C03 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F68A71CB16EA898900DF589B /* Build configuration list for PBXProject "BOSImageResizeOperation" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -387,6 +561,7 @@
 				F68A722916EA8B9000DF589B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Tests/BOSImageResizeOperation.xcodeproj/xcshareddata/xcschemes/BOSImageResizeOperation.xcscheme
+++ b/Tests/BOSImageResizeOperation.xcodeproj/xcshareddata/xcschemes/BOSImageResizeOperation.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "37F03FD41E373C9C00548C03"
+               BuildableName = "BOSImageResizeOperation.framework"
+               BlueprintName = "BOSImageResizeOperation"
+               ReferencedContainer = "container:BOSImageResizeOperation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "37F03FD41E373C9C00548C03"
+            BuildableName = "BOSImageResizeOperation.framework"
+            BlueprintName = "BOSImageResizeOperation"
+            ReferencedContainer = "container:BOSImageResizeOperation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "37F03FD41E373C9C00548C03"
+            BuildableName = "BOSImageResizeOperation.framework"
+            BlueprintName = "BOSImageResizeOperation"
+            ReferencedContainer = "container:BOSImageResizeOperation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
This creates a framework target inside the project and a shared scheme which allows carthage to compile the framework. Also fixes the `BOSImageResizeOperation.m:169:53: warning: enum values with underlying type 'NSInteger' should not be used as format arguments; add an explicit cast to 'long' instead [-Wformat]` warning, diff: https://github.com/arrrnas/BOSImageResizeOperation/pull/1/files
Also adds carthage badge the the readme.